### PR TITLE
Fixed for Node.js 0.5/0.6

### DIFF
--- a/src/tokyocabinet.cc
+++ b/src/tokyocabinet.cc
@@ -1,4 +1,5 @@
 #include <node.h>
+#include <node_version.h>
 #include <tcutil.h>
 #include <tchdb.h>
 #include <tcbdb.h>
@@ -120,13 +121,22 @@ inline Local<Object> tcmaptoobj (TCMAP *map) {
     return Undefined();                                                       \
   }                                                                           \
 
+#if NODE_VERSION_AT_LEAST(0, 5, 4)
+#define DEFINE_ASYNC_EXEC(name)                                               \
+  static void                                                                 \
+  Exec##name (eio_req *req) {                                                 \
+    name##AsyncData *data = static_cast<name##AsyncData *>(req->data);        \
+    req->result = data->run() ? TCESUCCESS : data->ecode();                   \
+  }
+#else
 #define DEFINE_ASYNC_EXEC(name)                                               \
   static int                                                                  \
   Exec##name (eio_req *req) {                                                 \
     name##AsyncData *data = static_cast<name##AsyncData *>(req->data);        \
     req->result = data->run() ? TCESUCCESS : data->ecode();                   \
     return 0;                                                                 \
-  }                                                                           \
+  }
+#endif
 
 #define DEFINE_ASYNC_AFTER(name)                                              \
   static int                                                                  \

--- a/test/async.js
+++ b/test/async.js
@@ -2,7 +2,7 @@
 // translated into JS.
 
 var sys = require('sys');
-var TC = require('../build/default/tokyocabinet');
+var TC = require('../build/tokyocabinet');
 var fs = require('fs');
 
 sys.puts("Tokyo Cabinet version " + TC.VERSION);

--- a/test/bench.js
+++ b/test/bench.js
@@ -1,7 +1,7 @@
 // Hash db bench
 
 var sys = require('sys');
-var TC = require('../build/default/tokyocabinet');
+var TC = require('../build/tokyocabinet');
 var fs = require('fs');
 
 sys.puts("Tokyo Cabinet version " + TC.VERSION);

--- a/test/sample.js
+++ b/test/sample.js
@@ -2,7 +2,7 @@
 // translated into JS.
 
 var sys = require('sys');
-var TC = require('../build/default/tokyocabinet');
+var TC = require('../build/tokyocabinet');
 var fs = require('fs');
 
 sys.puts("Tokyo Cabinet version " + TC.VERSION);

--- a/wscript
+++ b/wscript
@@ -1,3 +1,5 @@
+import os
+
 srcdir = "."
 blddir = "build"
 VERSION = "0.0.1"
@@ -9,6 +11,10 @@ def configure(conf):
   conf.check_tool("compiler_cxx")
   conf.check_tool("node_addon")
 
+def build_post(bld):
+  module_path = bld.path.find_resource('tokyocabinet.node').abspath(bld.env)
+  os.system('cp %r build/tokyocabinet.node' % module_path)
+  
 def build(bld):
   obj = bld.new_task_gen("cxx", "shlib", "node_addon")
   obj.target = "tokyocabinet"
@@ -16,3 +22,4 @@ def build(bld):
   obj.includes = ["."]
   obj.defines = "__STDC_LIMIT_MACROS"
   obj.lib = ["tokyocabinet"]
+  bld.add_post_fun(build_post)


### PR DESCRIPTION
Node.js 0.6 stable came out a few days ago. This patch makes node-tokyocabinet compatible with these newer Node.js versions.
